### PR TITLE
Update yahm-backup

### DIFF
--- a/bin/yahm-backup
+++ b/bin/yahm-backup
@@ -152,14 +152,19 @@ data_backup()
     progress "Creating Backup from /usr/local folder"
     cd ${LXC_ROOT_FS}
     tar $VERBOSE -czf ${YAHM_TMP}/usr_local.tar.gz usr/local
+#sign the stuff so ccu will also accept the backup file
+    lxc-attach -n ${LXCNAME} -- crypttool -s -t 1 <${YAHM_TMP}/usr_local.tar.gz >${YAHM_TMP}/signature
+    lxc-attach -n ${LXCNAME} -- crypttool -g -t 1 >${YAHM_TMP}/key_index
 
     progress "Creating Homematic backup file"
     timestamp=$(date +%s)
     cd ${YAHM_TMP}
-    tar $VERBOSE -cf ${YAHM_TMP}/homematic-ccu2-${timestamp}.sbk usr_local.tar.gz firmware_version
+#add signature and key_index
+    tar $VERBOSE -cf ${YAHM_TMP}/homematic-ccu2-${timestamp}.sbk usr_local.tar.gz firmware_version key_index signature
 
     info "Clean up"
-    rm -rf ${YAHM_TMP}/usr_local.tar.gz ${YAHM_TMP}/firmware_version
+
+    rm -rf ${YAHM_TMP}/usr_local.tar.gz ${YAHM_TMP}/firmware_version ${YAHM_TMP}/key_index ${YAHM_TMP}/signature 
 
     info "STATUS: CCU2 Backup was successfully created: ${YAHM_TMP}/homematic-ccu2-${timestamp}.sbk"
 }


### PR DESCRIPTION
Mahlzeit,
ich habe beim Testen zwischen verschiedenen PIs festgestellt, das das Backup, welches YAHM macht, nicht direkt über die WebGUI Oberfläche einzuspielen geht, weil es nicht signiert wurde.

Das habe ich hier mal korrigiert.
Es wird nichts anderes gemacht, als innerhalb des Containers einmal crypttool aufzurufen und eine Signatur erstellt.
