### PR TITLE
CCU Backup Move

### DIFF
--- a/bin/yahm-backup
+++ b/bin/yahm-backup
@@ -166,7 +166,22 @@ data_backup()
 
     rm -rf ${YAHM_TMP}/usr_local.tar.gz ${YAHM_TMP}/firmware_version ${YAHM_TMP}/key_index ${YAHM_TMP}/signature 
 
-    info "STATUS: CCU2 Backup was successfully created: ${YAHM_TMP}/homematic-ccu2-${timestamp}.sbk"
+#if there is a -d file move the backup to this file
+    if [ $DATA_FILE = "" ]
+    then
+     info "STATUS: CCU2 Backup was successfully created: ${YAHM_TMP}/homematic-ccu2-${timestamp}.sbk"
+    else
+    
+    if [[ -d $DATA_FILE ]]; then
+#if -d is path create my own name with day in it
+    FILENAME="$DATA_FILE/homematic-ccu2_$(date +%d).sbk"
+    else
+#else set FILENAME to -d Arg
+    FILENAME=$DATA_FILE
+    fi
+     mv ${YAHM_TMP}/homematic-ccu2-${timestamp}.sbk $FILENAME
+     info "STATUS: CCU2 Backup was successfully created: $FILENAME"
+    fi
 }
 
 data_restore()

--- a/share/yahm_completion
+++ b/share/yahm_completion
@@ -1,0 +1,42 @@
+_backup()
+{
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=( $(compgen -W "data_backup data_restore full_backup full_restore" -- "$word") )
+}
+
+_ctl()
+{
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=( $(compgen -W "start stop info join update" -- "$word") )
+}
+
+_lxc()
+{
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=( $(compgen -W "install update remove" -- "$word") )
+}
+
+_module()
+{
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=( $(compgen -W "enable dissable available installed" -- "$word") )
+}
+
+_network()
+{
+  COMPREPLY=()
+  local word="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=( $(compgen -W "create_bridge delete_bridge attach_bridge dettach_bridge show_bridge" -- "$word") )
+}
+
+
+complete -F _backup yahm-backup
+complete -F _ctl yahm-ctl
+complete -F _lxc yahm-lxc
+complete -F _network yahm-network
+complete -F _module yahm-moduleroot
+


### PR DESCRIPTION
Ich schon wieder ;o)

Ich hatte bisher einen Cron Job der tgl. ein CCU Backup auf ein NAS geschoben hat.
Dort wurden für jeden Tag ein Backup vorgehalten, und dann überschrieben.
Das habe ich hier jetzt mal implementiert.

Wenn bei data_backup der Parameter -d gesetzt wurde, wird nach Erstellung des Files im /tmp dieses nach -d verschoben.

Ist -d ein Pfad wird ein eigener Dateiname nach dem Template homematic-ccu2_XX.sbk erzeugt.
Wobei XX der Tag des aktuellen Datums ist.

Also erzeugt yahm-backup -d /mnt/backup data_backup am 1. ein Backup namens homematic-ccu2_01.sbk ... am 2. homematic_ccu2_02.sbk .. und so weiter ... 

Damit kann man eine tgl. Sicherung erstellen die monatlich rotiert ....

Vielleicht kannst Du es gebrauchen ;)
